### PR TITLE
Update foro/Themes/default/languages/EmailTemplates.spanish_es-utf8.php

### DIFF
--- a/foro/Themes/default/languages/EmailTemplates.spanish_es-utf8.php
+++ b/foro/Themes/default/languages/EmailTemplates.spanish_es-utf8.php
@@ -698,7 +698,7 @@ Before you can login and start using the forum, your request will be reviewed an
 			@description:
 		*/
 		'subject' => 'Respuesta a Tema: {TOPICSUBJECT}',
-		'body' => 'Se ha publicado una respuesta a un tema de {POSTERNAME} que estás observando.
+		'body' => 'Se ha publicado una respuesta de {POSTERNAME} a un tema que estás observando.
 
 Puedes ver la respuesta en: {TOPICLINK}
 


### PR DESCRIPTION
El template de mail está mal traducido. Dice: 

"Se ha publicado una respuesta a un tema de {POSTERNAME} que estabas observando."

Da a entender que estas observando un tema de {POSTERNAME} cuando en realidad lo que quiere decir es que {POSTERNAME} respondio a un tema(no aclara de quien) que estabas observando.

Es una pavada pero tampoco cuesta nada modificarlo
